### PR TITLE
fixes intermediate_image_sizes_advanced param size

### DIFF
--- a/files/class-image-sizes.php
+++ b/files/class-image-sizes.php
@@ -17,6 +17,9 @@ class ImageSizes {
 	/** @var Image Image to be resized. */
 	public $image;
 
+	/** @var int Attachment ID. */
+	public $attachment_id;
+
 	/** @var null|array $sizes Intermediate sizes. */
 	public static $sizes = null;
 
@@ -27,8 +30,9 @@ class ImageSizes {
 	 * @param array $data          Attachment metadata.
 	 */
 	public function __construct( $attachment_id, $data ) {
-		$this->data = $data;
-		$this->image = new Image( $data, get_post_mime_type( $attachment_id ) );
+		$this->data          = $data;
+		$this->attachment_id = $attachment_id;
+		$this->image         = new Image( $data, get_post_mime_type( $attachment_id ) );
 		$this->generate_sizes();
 	}
 
@@ -99,7 +103,7 @@ class ImageSizes {
 		remove_filter( 'intermediate_image_sizes_advanced', 'wpcom_intermediate_sizes' );
 
 		/** This filter is documented in wp-admin/includes/image.php */
-		$sizes = apply_filters( 'intermediate_image_sizes_advanced', static::$sizes, $this->data );
+		$sizes = apply_filters( 'intermediate_image_sizes_advanced', static::$sizes, $this->data, $this->attachment_id );
 
 		// Re-add the filter removed above.
 		add_filter( 'intermediate_image_sizes_advanced', 'wpcom_intermediate_sizes' );


### PR DESCRIPTION
As per https://developer.wordpress.org/reference/hooks/intermediate_image_sizes_advanced/, the filter now accepts 3 parameters, to not break compatibility with other filters, it would be good to add the third parameter.

## Description
Fixed the `intermediate_image_sizes_advanced` filter by adding the attachment_id third parameter.

## Changelog Description
#### Improved compatibility

- fixes the `intermediate_image_sizes_advanced` filter by adding the attachment_id third parameter

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples. 
